### PR TITLE
tightened HK type bound

### DIFF
--- a/src/TravelingSalesmanHeuristics.jl
+++ b/src/TravelingSalesmanHeuristics.jl
@@ -368,11 +368,14 @@ function hkinspired_bound(distmat)
 		return distmat[keep, keep]
 	end
 	
+	# make sure min(distmat[v,:]) doesn't pick diagonal elements
+	m = maximum(distmat)
+	distmat_nodiag = distmat + m * eye(distmat)
 	function cost_leave_out(v)
 		dmprime = del_vert(v)
 		_, c = minspantree(dmprime)
-		c += minimum(distmat[v,:])
-		c += minimum(distmat[:,v])
+		c += minimum(distmat_nodiag[v,:])
+		c += minimum(distmat_nodiag[:,v])
 		return c
 	end
 	


### PR DESCRIPTION
The HK inspired bounds here are computed by choosing a vertex `v`, finding a minimum spanning tree on the other vertices, and adding the cost of the cheapest edge to `v` and the cheapest edge from `v`. Prior to this that cheapest edge could be the 0 cost self loop.

The HK inspired bound is pretty slow. About half the time is spent on creating new graph objects - makes the code look clean, but this is avoidable. The other half is spent on computing MSTs. It's not currently obvious to me how to speed that up without loosening the bound. Using the spanning tree from leaving out vertex `v` as a "warm start" for computing the tree when leaving out `v'` sounds appealing, but that tree minus `v` is no longer obviously a MST on `E - {v, v'}`. But all that's a PR for another day.
