### PR TITLE
Two-opt performance improvements, especially for symmetric problems.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,7 +1,7 @@
 using Documenter, TravelingSalesmanHeuristics
 
 makedocs(
-	format = :html,
+	format = Documenter.HTML(),
 	sitename = "Traveling Salesman Heuristics",
 	pages = [
 		"Home" => "index.md",
@@ -15,6 +15,6 @@ deploydocs(
     target = "build",
     deps   = nothing,
     make   = nothing,
-	julia  = "0.7",
+	julia  = "1.1",
 	osname = "linux"
 )

--- a/src/TravelingSalesmanHeuristics.jl
+++ b/src/TravelingSalesmanHeuristics.jl
@@ -330,6 +330,12 @@ medium problem instances.
 See also [`simulated_annealing`](@ref) for another path generation heuristic.
 """
 function two_opt(distmat::AbstractMatrix{T}, path::AbstractVector{S}) where {T<:Real, S<:Integer}
+    # We can accelerate if the instance is symmetric
+    issymmetric(distmat) && (distmat = Symmetric(distmat))
+    return _two_opt_logic(distmat, path)
+end
+
+function _two_opt_logic(distmat::AbstractMatrix{T}, path::AbstractVector{S}) where {T<:Real, S<:Integer}
     # size checks
     n = length(path)
     if size(distmat, 1) != size(distmat, 2)
@@ -338,6 +344,9 @@ function two_opt(distmat::AbstractMatrix{T}, path::AbstractVector{S}) where {T<:
 
     # don't modify input
     path = copy(path) # Int is a bitstype
+    
+    # how much must each swap improve the cost?
+    thresh = improvement_threshold(T)
 
     # main loop
     # check every possible switch until no 2-swaps reduce objective
@@ -347,16 +356,16 @@ function two_opt(distmat::AbstractMatrix{T}, path::AbstractVector{S}) where {T<:
     # if the path is not a cycle, we should respect the endpoints
     switchLow = 2
     switchHigh = n - 1
-    prevCost = Inf
-    curCost = pathcost(distmat, path)
-    while prevCost > pathcost(distmat, path)
-        prevCost = curCost
+    need_to_loop = true # always look for swaps at least once
+    swaps = 0
+    while need_to_loop
+        need_to_loop = false
         # we can't change the first
         for i in switchLow:(switchHigh-1)
             for j in switchHigh:-1:(i+1)
-                altCost = pathcost_rev(distmat, path, i, j)
-                if altCost < curCost
-                    curCost = altCost
+                cost_change = pathcost_rev_delta(distmat, path, i, j)
+                if cost_change + thresh <= 0
+                    need_to_loop = true
                     reverse!(path, i, j)
                 end
             end

--- a/src/TravelingSalesmanHeuristics.jl
+++ b/src/TravelingSalesmanHeuristics.jl
@@ -357,7 +357,6 @@ function _two_opt_logic(distmat::AbstractMatrix{T}, path::AbstractVector{S}) whe
     switchLow = 2
     switchHigh = n - 1
     need_to_loop = true # always look for swaps at least once
-    swaps = 0
     while need_to_loop
         need_to_loop = false
         # we can't change the first

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -71,39 +71,10 @@ function pathcost(distmat::AbstractMatrix{T}, path::AbstractArray{S},
     return cost
 end
 
-"Compute the cost of walking along the entire path specified but reversing the
-sequence from `revLow` to `revHigh`, inclusive."
-function pathcost_rev(distmat::AbstractMatrix{T}, path::AbstractArray{S},
-                      revLow::Int, revHigh::Int) where {T<:Real, S<:Integer}
-    cost = zero(T)
-    # if there's an initial unreversed section
-    if revLow > 1
-        for i in 1:(revLow - 2)
-            @inbounds cost += distmat[path[i], path[i+1]]
-        end
-        # from end of unreversed section to beginning of reversed section
-        @inbounds cost += distmat[path[revLow - 1], path[revHigh]]
-    end
-    # main reverse section
-    for i in revHigh:-1:(revLow + 1)
-        @inbounds cost += distmat[path[i], path[i-1]]
-    end
-    # if there's an unreversed section after the reversed bit
-    n = length(path)
-    if revHigh < length(path)
-        # from end of reversed section back to regular
-        @inbounds cost += distmat[path[revLow], path[revHigh + 1]]
-        for i in (revHigh + 1):(n-1)
-            @inbounds cost += distmat[path[i], path[i+1]]
-        end
-    end
-    return cost
-end
-
 "Compute the change in cost from reversing the subset of the path from indices
 `revLow` to `revHigh`, inclusive."
 function pathcost_rev_delta(distmat::AbstractMatrix{T}, path::AbstractArray{S},
-                      revLow::Int, revHigh::Int) where {T<:Real, S<:Integer}
+                            revLow::Int, revHigh::Int) where {T<:Real, S<:Integer}
     cost_delta = zero(T)
     # if there's an initial unreversed section
     if revLow > 1
@@ -156,11 +127,11 @@ end
 
 "Due to floating point imprecision, various path refinement heuristics may get
 stuck in infinite loops as both doing and un-doing a particular change apparently
-improves the path cost. For example, floating point error may suggest that reversing
-and un-reversing a path for a symmetric TSP instance improves the cost slightly. To
-avoid such false-improvement infinite loops, limit refinement heuristics to
-improvements with some minimum magnitude defined by the element type of the distance
-matrix."
+improves the path cost. For example, floating point error may suggest that both 
+reversing and un-reversing a path for a symmetric TSP instance improves the cost 
+slightly. To avoid such false-improvement infinite loops, limit refinement heuristics
+to improvements with some minimum magnitude defined by the element type of the
+distance matrix."
 improvement_threshold(T::Type{<:Integer}) = one(T)
 improvement_threshold(T::Type{<:AbstractFloat}) = sqrt(eps(one(T)))
 improvement_threshold(T::Type{<:Real}) = sqrt(eps(1.0))

--- a/src/simulated_annealing.jl
+++ b/src/simulated_annealing.jl
@@ -34,7 +34,6 @@ function simulated_annealing(distmat::Matrix{T} where {T<:Real};
     function sahelper!(path)
         temp = init_temp / cool_rate # divide by cool_rate so when we first multiply we get init_temp
         n = size(distmat, 1)
-        cost_cur = pathcost(distmat, path)
 
         for i in 1:steps
             temp *= cool_rate
@@ -45,16 +44,15 @@ function simulated_annealing(distmat::Matrix{T} where {T<:Real};
             if first > last
                 first, last = last, first
             end
-            cost_other = pathcost_rev(distmat, path, first, last)
-            @fastmath accept = cost_other < cost_cur ? true : rand() < exp((cost_cur - cost_other) / temp)
+            cost_delta = pathcost_rev_delta(distmat, path, first, last)
+            @fastmath accept = cost_delta < 0 ? true : rand() < exp(-cost_delta / temp)
             # should we accept?
             if accept
                 reverse!(path, first, last)
-                cost_cur = cost_other
             end
         end
 
-        return path, cost_cur
+        return path, pathcost(distmat, path)
     end
 
     # unpack the initial path

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using TravelingSalesmanHeuristics
+const TSP = TravelingSalesmanHeuristics
 using Test
 using Random
 using LinearAlgebra
@@ -135,13 +136,14 @@ end
 function test_path_costs()
 	dm = [1 2 3; 4 5 6; 7 8 9]
 	p1 = [1, 2, 3, 1]
-	@test TravelingSalesmanHeuristics.pathcost(dm, p1) == 2 + 6 + 7
+    orig_cost = 2 + 6 + 7
+	@test TSP.pathcost(dm, p1) == orig_cost
 	# various reverse indices to test
 	revs = [(1,4), (2,3), (2,4), (3,3)]
 	for rev in revs
 		path_rev = reverse(p1, rev[1], rev[2])
-		@test TravelingSalesmanHeuristics.pathcost(dm, path_rev) == 
-			  TravelingSalesmanHeuristics.pathcost_rev(dm, p1, rev[1], rev[2])
+		@test TSP.pathcost(dm, path_rev) ≈
+			  orig_cost + TSP.pathcost_rev_delta(dm, p1, rev[1], rev[2])
 	end
 end
 


### PR DESCRIPTION
Improve performance of two-opt path refinements. Previously we calculated the entire cost of a partially-reversed path; now we just calculate the change in cost. In almost all cases, this improves performance. Additionally, add a version of the change-in-cost calculation for symmetric distance matrices.

Under this change, some small asymmetric instances have slightly degraded two-opt performance. Since two-opt is already fast for small instances and performance improves for larger instances, this seems an acceptable trade.