### PR TITLE
type information for `randpath(n)`

### DIFF
--- a/src/simulated_annealing.jl
+++ b/src/simulated_annealing.jl
@@ -79,8 +79,8 @@ function simulated_annealing(distmat::Matrix{T} where {T<:Real};
     return path, cost
 end
 
-function randpath(n)
-    path = 1:n |> collect |> shuffle
+function randpath(n::Int)
+    path = shuffle(1:n)
     push!(path, path[1]) # loop
     return path
 end


### PR DESCRIPTION
Previously:

```
julia> @code_warntype simulated_annealing(M)
MethodInstance for TravelingSalesmanHeuristics.simulated_annealing(::Matrix{Int64})
  from simulated_annealing(distmat::Matrix{T} where T<:Real; steps, num_starts, init_temp, final_temp, init_path) in TravelingSalesmanHeuristics at /Users/chkwon/.julia/dev/TravelingSalesmanHeuristics/src/simulated_annealing.jl:21
Arguments
  #self#::Core.Const(TravelingSalesmanHeuristics.simulated_annealing)
  distmat::Matrix{Int64}
Body::Tuple{AbstractArray, Any}
1 ─ %1 = TravelingSalesmanHeuristics.length(distmat)::Int64
│   %2 = (50 * %1)::Int64
│   %3 = TravelingSalesmanHeuristics.exp(8)::Core.Const(2980.9579870417283)
│   %4 = TravelingSalesmanHeuristics.exp(-6.5)::Core.Const(0.0015034391929775724)
│   %5 = TravelingSalesmanHeuristics.:(var"#simulated_annealing#5")(%2, 1, %3, %4, TravelingSalesmanHeuristics.nothing, #self#, distmat)::Tuple{AbstractArray, Any}
└──      return %5
```

There are abstract types involved as in `Tuple{AbstractArray, Any}`.


After the change:

```
julia> @code_warntype simulated_annealing(M)
MethodInstance for TravelingSalesmanHeuristics.simulated_annealing(::Matrix{Int64})
  from simulated_annealing(distmat::Matrix{T} where T<:Real; steps, num_starts, init_temp, final_temp, init_path) in TravelingSalesmanHeuristics at /Users/chkwon/.julia/dev/TravelingSalesmanHeuristics/src/simulated_annealing.jl:21
Arguments
  #self#::Core.Const(TravelingSalesmanHeuristics.simulated_annealing)
  distmat::Matrix{Int64}
Body::Tuple{Vector{Int64}, Int64}
1 ─ %1 = TravelingSalesmanHeuristics.length(distmat)::Int64
│   %2 = (50 * %1)::Int64
│   %3 = TravelingSalesmanHeuristics.exp(8)::Core.Const(2980.9579870417283)
│   %4 = TravelingSalesmanHeuristics.exp(-6.5)::Core.Const(0.0015034391929775724)
│   %5 = TravelingSalesmanHeuristics.:(var"#simulated_annealing#5")(%2, 1, %3, %4, TravelingSalesmanHeuristics.nothing, #self#, distmat)::Tuple{Vector{Int64}, Int64}
└──      return %5
```